### PR TITLE
create a catcher for future darwin2x releases

### DIFF
--- a/perlmod/Fink/Bootstrap.pm
+++ b/perlmod/Fink/Bootstrap.pm
@@ -269,6 +269,12 @@ GCC_MSG
 	} elsif ($host =~ /^i386-apple-darwin20\.[0-1]/) {
 		&print_breaking("This system is supported and tested.");
 		$distribution = "11.0";
+	} elsif ($host =~ /^i386-apple-darwin2(\d+)\./) {
+		&print_breaking("This system was not released at the time " .
+			"this Fink release was made.  Prerelease versions " .
+			"of macOS might work with Fink, but there are no " .
+			"guarantees.");
+		$distribution = "11." . ($1-20);
 	} elsif ($host =~ /^i386-apple-darwin(\d+)\./) {
 		&print_breaking("This system was not released at the time " .
 			"this Fink release was made.  Prerelease versions " .


### PR DESCRIPTION
Unreleased darwin2x releases should default to Dist:11.x rather than 10.y