### PR TITLE
Updates for Big Sur to dpkg1.16 branch

### DIFF
--- a/perlmod/Fink/Bootstrap.pm
+++ b/perlmod/Fink/Bootstrap.pm
@@ -4,7 +4,7 @@
 #
 # Fink - a package manager that downloads source and installs it
 # Copyright (c) 2001 Christoph Pfisterer
-# Copyright (c) 2001-2020 The Fink Package Manager Team
+# Copyright (c) 2001-2021 The Fink Package Manager Team
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -266,15 +266,21 @@ GCC_MSG
 			"of macOS might work with Fink, but there are no " .
 			"guarantees.");
 		$distribution = "10.15";
-	} elsif ($host =~ /^i386-apple-darwin20\.[0-1]/) {
+	} elsif ($host =~ /^i386-apple-darwin20\.[0-2]/) {
 		&print_breaking("This system is supported and tested.");
+		$distribution = "11.0";
+	} elsif ($host =~ /^i386-apple-darwin20\./) {
+		&print_breaking("This system was not released at the time " .
+			"this Fink release was made.  Prerelease versions " .
+			"of macOS might work with Fink, but there are no " .
+			"guarantees.");
 		$distribution = "11.0";
 	} elsif ($host =~ /^i386-apple-darwin2(\d+)\./) {
 		&print_breaking("This system was not released at the time " .
 			"this Fink release was made.  Prerelease versions " .
 			"of macOS might work with Fink, but there are no " .
 			"guarantees.");
-		$distribution = "11." . ($1-20);
+		$distribution = "11." . ($1-1);
 	} elsif ($host =~ /^i386-apple-darwin(\d+)\./) {
 		&print_breaking("This system was not released at the time " .
 			"this Fink release was made.  Prerelease versions " .

--- a/perlmod/Fink/PkgVersion.pm
+++ b/perlmod/Fink/PkgVersion.pm
@@ -963,7 +963,8 @@ sub prepare_percent_c {
 			"INSTALLSITEMAN3DIR=\%p/share/man/man3 " .
 			"INSTALLBIN=\%p/bin " .
 			"INSTALLSITEBIN=\%p/bin " .
-			"INSTALLSCRIPT=\%p/bin ";
+			"INSTALLSCRIPT=\%p/bin " .
+			"INSTALLSITESCRIPT=\%p/bin ";
 
 	} elsif ($type eq 'modulebuild') {
 		# grab perl version, if present
@@ -1255,7 +1256,7 @@ sub get_script {
 			# grab perl version, if present
 			my ($perldirectory, $perlarchdir) = $self->get_perl_dir_arch();
 			$default_script =
-				"/usr/bin/make -j1 install PREFIX=\%p INSTALLPRIVLIB=\%p/lib/perl5$perldirectory INSTALLARCHLIB=\%p/lib/perl5$perldirectory/$perlarchdir INSTALLSITELIB=\%p/lib/perl5$perldirectory INSTALLSITEARCH=\%p/lib/perl5$perldirectory/$perlarchdir INSTALLMAN1DIR=\%p/share/man/man1 INSTALLMAN3DIR=\%p/share/man/man3 INSTALLSITEMAN1DIR=\%p/share/man/man1 INSTALLSITEMAN3DIR=\%p/share/man/man3 INSTALLBIN=\%p/bin INSTALLSITEBIN=\%p/bin INSTALLSCRIPT=\%p/bin DESTDIR=\%d\n";
+				"/usr/bin/make -j1 install PREFIX=\%p INSTALLPRIVLIB=\%p/lib/perl5$perldirectory INSTALLARCHLIB=\%p/lib/perl5$perldirectory/$perlarchdir INSTALLSITELIB=\%p/lib/perl5$perldirectory INSTALLSITEARCH=\%p/lib/perl5$perldirectory/$perlarchdir INSTALLMAN1DIR=\%p/share/man/man1 INSTALLMAN3DIR=\%p/share/man/man3 INSTALLSITEMAN1DIR=\%p/share/man/man1 INSTALLSITEMAN3DIR=\%p/share/man/man3 INSTALLBIN=\%p/bin INSTALLSITEBIN=\%p/bin INSTALLSCRIPT=\%p/bin INSTALLSITESCRIPT=\%p/bin DESTDIR=\%d\n";
 		} elsif ($type eq 'modulebuild') {
 			$default_script =
 				"./Build install\n";

--- a/perlmod/Fink/Services.pm
+++ b/perlmod/Fink/Services.pm
@@ -5,7 +5,7 @@
 #
 # Fink - a package manager that downloads source and installs it
 # Copyright (c) 2001 Christoph Pfisterer
-# Copyright (c) 2001-2020 The Fink Package Manager Team
+# Copyright (c) 2001-2021 The Fink Package Manager Team
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -1438,12 +1438,14 @@ sub get_darwin_equiv {
 		'1' => '10.0',
 	);
 	my $kernel_vers = get_kernel_vers();
+	my $kernel_vers_minor = get_kernel_vers_minor();
 	if ($kernel_vers <= 19) {
 		# darwin19 == 10.15
 		return $darwin_osx{$kernel_vers} || '10.' . ($kernel_vers-4);
 	} elsif ($kernel_vers == 20) {
-		# darwin20 == 11.0
-		return $darwin_osx{$kernel_vers} || '11.' . ($kernel_vers-20);
+		# darwin20.1 == 11.0
+		# darwin20.2 == 11.1
+		return $darwin_osx{$kernel_vers} || '11.' . ($kernel_vers_minor-1);
 	}
 }
 
@@ -1461,6 +1463,16 @@ sub get_kernel_vers {
 		return $kernel_version;
 	} else {
 		my $error = "Couldn't determine major version number for $kernel_version kernel!";
+		die $error . "\n";
+	}
+}
+
+sub get_kernel_vers_minor {
+	my $kernel_version_minor = get_kernel_vers_long();
+	if ($kernel_version_minor =~ s/^\d+\.(\d+).*/$1/) {
+		return $kernel_version_minor;
+	} else {
+		my $error = "Couldn't determine minor version number for $kernel_version_minor kernel!";
 		die $error . "\n";
 	}
 }


### PR DESCRIPTION
1) cherry pick commit from master to add needed INSTALLSITESCRIPT to EU::MM scripts
2) deal with new paradigm that Apple is using to track sw_vers to darwin version.
For now, we're assuming that darwin20.* will all be dist=11.0 (holds for macOS 11.0 through 11.1). And assumes we'll have to switch to dist=11.1 when darwin21 comes out (assuming same yearly major version upgrade as before). We can always fix these assumptions if needed later.