### PR TITLE
dpkg.patch: fix --with-finkvirtuals option name

### DIFF
--- a/10.9-libcxx/dpkg-bootstrap.info
+++ b/10.9-libcxx/dpkg-bootstrap.info
@@ -9,7 +9,7 @@ Source-MD5: bdb6d88470c901d35fa19d776a8e8828
 SourceDirectory: dpkg-%v
 
 PatchFile: dpkg.patch
-PatchFile-MD5: 2754c94569bbf7c2150557a600f07fee
+PatchFile-MD5: e42321211f3f963b16fec94219d320ac
 
 PatchScript: <<
 sed -e 's,@FINKPREFIX@,%p,g' %{PatchFile} | patch -p1

--- a/10.9-libcxx/dpkg.info
+++ b/10.9-libcxx/dpkg.info
@@ -38,7 +38,7 @@ Source-MD5: bdb6d88470c901d35fa19d776a8e8828
 SourceDirectory: dpkg-%v
 
 PatchFile: dpkg.patch
-PatchFile-MD5: 2754c94569bbf7c2150557a600f07fee
+PatchFile-MD5: e42321211f3f963b16fec94219d320ac
 
 PatchScript: <<
 sed -e 's,@FINKPREFIX@,%p,g' %{PatchFile} | patch -p1

--- a/10.9-libcxx/dpkg.patch
+++ b/10.9-libcxx/dpkg.patch
@@ -991,7 +991,7 @@ diff -ruN dpkg-1.17.6.orig/fink/patches/extra-statusfile.patch dpkg-1.17.6/fink/
 + enable_start_stop_daemon
 + enable_update_alternatives
 + with_dpkg_env_script
-++with_finkvirtual
+++with_finkvirtuals
 + with_pkgconfdir
 + with_admindir
 + with_logdir


### PR DESCRIPTION
Fixes: configure: WARNING: unrecognized options: --with-finkvirtuals

This doesn't fix the following issue for me (trying to get an M1 working) but it seems like it might help:

Can't resolve dependency "install-info" for package "dpkg-1.17.6-1.5" (no matching packages/versions found)
